### PR TITLE
Modify Factory keys to simplify common case with single configuration block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# 0.9.2
+1. [[TAY-7](https://github.com/danthorpe/TaylorSource/pull/7)]: Simplifies the common case of having a factory with a single cell type. In such a scenario, initialization of the Factory class requires no key closures, and cell/view registration takes no key parameter.

--- a/Example/Datasources/ViewController.swift
+++ b/Example/Datasources/ViewController.swift
@@ -39,12 +39,7 @@ struct EventsDatasource: DatasourceProviderType {
 
     init(color: Event.Color, db: YapDatabase, view: Factory.ViewType) {
 
-        let factory = Factory(
-            cell: { (item, index) in Event.collection },
-            supplementary: { index in Event.collection }
-        )
-
-        var ds = YapDBDatasource(id: "\(color) events datasource", database: db, factory: factory, processChanges: view.processChanges, configuration: eventsWithColor(color, byColor: true) { mappings in
+        var ds = YapDBDatasource(id: "\(color) events datasource", database: db, factory: Factory(), processChanges: view.processChanges, configuration: eventsWithColor(color, byColor: true) { mappings in
             mappings.setIsReversed(true, forGroup: "\(color)")
         })
 
@@ -53,7 +48,7 @@ struct EventsDatasource: DatasourceProviderType {
         eventColor = color
         readWriteConnection = db.newConnection()
         datasource = ds
-        datasource.factory.registerCell(.ClassWithIdentifier(EventCell.self, "cell"), inView: view, withKey: Event.collection, configuration: EventCell.configuration())
+        datasource.factory.registerCell(.ClassWithIdentifier(EventCell.self, "cell"), inView: view, configuration: EventCell.configuration())
     }
 
     func addEvent(event: Event) {

--- a/Example/DatasourcesTests/DatasourcesTests.swift
+++ b/Example/DatasourcesTests/DatasourcesTests.swift
@@ -14,7 +14,7 @@ class StaticDatasourceTests: XCTestCase {
     typealias Datasource = StaticDatasource<Factory>
 
     let view = StubbedTableView()
-    let factory = Factory(cellKey: "cell-key", supplementaryKey: "supplementary-key")
+    let factory = Factory()
     let data: [Event] = map(0..<5) { (index) -> Event in Event.create() }
     var datasource: Datasource!
 
@@ -31,20 +31,25 @@ class StaticDatasourceTests: XCTestCase {
     }
 
     override func setUp() {
-        factory.registerCell(.ClassWithIdentifier(UITableViewCell.self, "cell"), inView: view, withKey: "cell-key") { (_, _, _) in }
+        factory.registerCell(.ClassWithIdentifier(UITableViewCell.self, "cell"), inView: view) { (_, _, _) in }
         datasource = Datasource(id: "test datasource", factory: factory, items: data)
     }
 
-    func registerHeader(key: String = "supplementary-key", config: Factory.SupplementaryViewConfiguration) {
+    func registerHeader(key: String? = .None, config: Factory.SupplementaryViewConfiguration) {
         registerSupplementaryView(.Header, key: key, config: config)
     }
 
-    func registerFooter(key: String = "supplementary-key", config: Factory.SupplementaryViewConfiguration) {
+    func registerFooter(key: String? = .None, config: Factory.SupplementaryViewConfiguration) {
         registerSupplementaryView(.Footer, key: key, config: config)
     }
 
-    func registerSupplementaryView(kind: SupplementaryElementKind, key: String = "supplementary-key", config: Factory.SupplementaryViewConfiguration) {
-        datasource.factory.registerSupplementaryView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "\(kind)"), kind: kind, inView: view, withKey: key, configuration: config)
+    func registerSupplementaryView(kind: SupplementaryElementKind, key: String? = .None, config: Factory.SupplementaryViewConfiguration) {
+        if let key = key {
+            datasource.factory.registerSupplementaryView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "\(kind)"), kind: kind, inView: view, withKey: key, configuration: config)
+        }
+        else {
+            datasource.factory.registerSupplementaryView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "\(kind)"), kind: kind, inView: view, configuration: config)
+        }
     }
 
     func validateSupplementaryView(kind: SupplementaryElementKind, exists: Bool, atIndexPath indexPath: NSIndexPath) {

--- a/Example/DatasourcesTests/PresentationFactoryTests.swift
+++ b/Example/DatasourcesTests/PresentationFactoryTests.swift
@@ -13,7 +13,7 @@ class UITableViewTests: XCTestCase {
     typealias Factory = BasicFactory<Event, UITableViewCell, UITableViewHeaderFooterView, StubbedTableView>
 
     let view = StubbedTableView()
-    let factory = Factory(cellKey: "cell-key", supplementaryKey: "supplementary-key")
+    let factory = Factory()
 
     var validIndexPath: NSIndexPath {
         return NSIndexPath(forRow: 0, inSection: 0)
@@ -27,62 +27,62 @@ class UITableViewTests: XCTestCase {
     // Tests
 
     func test_GivenRegisteredCell_WhenAccessingCellForItem_ThatCellIsReturned() {
-        registerCellWithKey("cell-key") { (_, _, _) in }
+        registerCell { (_, _, _) in }
         let cell = factory.cellForItem(Event.create(), inView: view, atIndex: validIndexPath)
         XCTAssertNotNil(cell, "Cell should be returned")
     }
 
     func test_GivenRegisteredCell_WhenAccessingCellForItem_ThatConfigurationBlockIsRun() {
         var blockDidRun = false
-        registerCellWithKey("cell-key") { (cell, item, index) in blockDidRun = true }
+        registerCell { (cell, item, index) in blockDidRun = true }
         let cell = factory.cellForItem(Event.create(), inView: view, atIndex: validIndexPath)
         XCTAssertTrue(blockDidRun, "Configuration block was not run.")
     }
 
     func test_GivenRegisteredHeaderView_WhenAccessingHeader_ThatViewIsReturned() {
-        registerHeaderWithKey("supplementary-key") { (_, _) in }
+        registerHeader { (_, _) in }
         let supplementary = factory.supplementaryViewForKind(.Header, inView: view, atIndex: validIndexPath)
         XCTAssertNotNil(supplementary, "View should be returned.")
     }
 
     func test_GivenRegisteredHeaderView_WhenAccessingHeader_ThatConfigurationBlockIsRun() {
         var blockDidRun = false
-        registerHeaderWithKey("supplementary-key") { (view, index) in blockDidRun = true }
+        registerHeader { (view, index) in blockDidRun = true }
         let supplementary = factory.supplementaryViewForKind(.Header, inView: view, atIndex: validIndexPath)
         XCTAssertTrue(blockDidRun, "Configuration block was not run.")
     }
 
     func test_GivenRegisteredHeaderView_WhenAccessingFooter_ThatViewIsNotReturned() {
         var blockDidRun = false
-        registerHeaderWithKey("supplementary-key") { (_, _) in blockDidRun = true }
+        registerHeader { (_, _) in blockDidRun = true }
         let supplementary = factory.supplementaryViewForKind(.Footer, inView: view, atIndex: validIndexPath)
         XCTAssertNil(supplementary, "No view should be returned.")
         XCTAssertFalse(blockDidRun, "Configuration block should not have been run.")
     }
 
     func test_GivenRegisteredFooterView_WhenAccessingFooter_ThatViewIsReturned() {
-        registerFooterWithKey("supplementary-key") { (_, _) in }
+        registerFooter { (_, _) in }
         let supplementary = factory.supplementaryViewForKind(.Footer, inView: view, atIndex: validIndexPath)
         XCTAssertNotNil(supplementary, "View should be returned.")
     }
 
     func test_GivenRegisteredFooterView_WhenAccessingHeader_ThatViewIsNotReturned() {
         var blockDidRun = false
-        registerFooterWithKey("supplementary-key") { (_, _) in blockDidRun = true }
+        registerFooter { (_, _) in blockDidRun = true }
         let supplementary = factory.supplementaryViewForKind(.Header, inView: view, atIndex: validIndexPath)
         XCTAssertNil(supplementary, "No view should be returned.")
         XCTAssertFalse(blockDidRun, "Configuration block should not have been run.")
     }
 
     func test_GivenRegisteredCustomView_WhenAccessingCustomView_ThatViewIsReturned() {
-        factory.registerSupplementaryView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "sidebar"), kind: .Custom("Sidebar"), inView: view, withKey: "supplementary-key") { (_, _) in }
+        factory.registerSupplementaryView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "sidebar"), kind: .Custom("Sidebar"), inView: view) { (_, _) in }
         let supplementary = factory.supplementaryViewForKind(.Custom("Sidebar"), inView: view, atIndex: validIndexPath)
         XCTAssertNotNil(supplementary, "View should be returned.")
     }
 
     func test_GivenRegisteredCustomView_WhenAccessingDifferentCustomView_ThatViewIsNotReturned() {
         var blockDidRun = false
-        factory.registerSupplementaryView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "sidebar"), kind: .Custom("Left Sidebar"), inView: view, withKey: "supplementary-key") { (_, _) in blockDidRun = true }
+        factory.registerSupplementaryView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "sidebar"), kind: .Custom("Left Sidebar"), inView: view) { (_, _) in blockDidRun = true }
         let supplementary = factory.supplementaryViewForKind(.Custom("Right Sidebar"), inView: view, atIndex: validIndexPath)
         XCTAssertNil(supplementary, "No view should be returned.")
         XCTAssertFalse(blockDidRun, "Configuration block should not have been run.")
@@ -90,16 +90,31 @@ class UITableViewTests: XCTestCase {
 
     // Helpers
 
-    func registerCellWithKey(key: String, config: Factory.CellConfiguration) {
-        factory.registerCell(.ClassWithIdentifier(UITableViewCell.self, "cell"), inView: view, withKey: key, configuration: config)
+    func registerCell(key: String? = .None, config: Factory.CellConfiguration) {
+        if let key = key {
+            factory.registerCell(.ClassWithIdentifier(UITableViewCell.self, "cell"), inView: view, withKey: key, configuration: config)
+        }
+        else {
+            factory.registerCell(.ClassWithIdentifier(UITableViewCell.self, "cell"), inView: view, configuration: config)
+        }
     }
 
-    func registerHeaderWithKey(key: String, config: Factory.SupplementaryViewConfiguration) {
-        factory.registerHeaderView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "header"), inView: view, withKey: key, configuration: config)
+    func registerHeader(key: String? = .None, config: Factory.SupplementaryViewConfiguration) {
+        if let key = key {
+            factory.registerHeaderView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "header"), inView: view, withKey: key, configuration: config)
+        }
+        else {
+            factory.registerHeaderView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "header"), inView: view, configuration: config)
+        }
     }
 
-    func registerFooterWithKey(key: String, config: Factory.SupplementaryViewConfiguration) {
-        factory.registerFooterView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "footer"), inView: view, withKey: key, configuration: config)
+    func registerFooter(key: String? = .None, config: Factory.SupplementaryViewConfiguration) {
+        if let key = key {
+            factory.registerFooterView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "footer"), inView: view, withKey: key, configuration: config)
+        }
+        else {
+            factory.registerFooterView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "footer"), inView: view, configuration: config)
+        }
     }
 }
 
@@ -108,7 +123,7 @@ class UICollectionViewTests: XCTestCase {
     typealias Factory = BasicFactory<Event, UICollectionViewCell, UICollectionReusableView, StubbedCollectionView>
 
     let view = StubbedCollectionView(frame: CGRectZero, collectionViewLayout: UICollectionViewFlowLayout())
-    let factory = Factory(cellKey: "cell-key", supplementaryKey: "supplementary-key")
+    let factory = Factory()
 
     var validIndexPath: NSIndexPath {
         return NSIndexPath(forItem: 0, inSection: 0)
@@ -122,78 +137,94 @@ class UICollectionViewTests: XCTestCase {
     // Tests
 
     func test_GivenRegisteredCell_WhenAccessingCellForItem_ThatCellIsReturned() {
-        registerCellWithKey("cell-key") { (_, _, _) in }
+        registerCell { (_, _, _) in }
         let cell = factory.cellForItem(Event.create(), inView: view, atIndex: validIndexPath)
         XCTAssertNotNil(cell, "Cell should be returned")
     }
 
     func test_GivenRegisteredCell_WhenAccessingCellForItem_ThatConfigurationBlockIsRun() {
         var blockDidRun = false
-        registerCellWithKey("cell-key") { (cell, item, index) in blockDidRun = true }
+        registerCell { (_, _, _) in blockDidRun = true }
         let cell = factory.cellForItem(Event.create(), inView: view, atIndex: validIndexPath)
         XCTAssertTrue(blockDidRun, "Configuration block was not run.")
     }
 
     func test_GivenRegisteredHeaderView_WhenAccessingHeader_ThatViewIsReturned() {
-        registerHeaderWithKey("supplementary-key") { (_, _) in }
+        registerHeader { (_, _) in }
         let supplementary = factory.supplementaryViewForKind(.Header, inView: view, atIndex: validIndexPath)
         XCTAssertNotNil(supplementary, "View should be returned.")
     }
 
     func test_GivenRegisteredHeaderView_WhenAccessingHeader_ThatConfigurationBlockIsRun() {
         var blockDidRun = false
-        registerHeaderWithKey("supplementary-key") { (view, index) in blockDidRun = true }
+        registerHeader { (_, _) in blockDidRun = true }
         let supplementary = factory.supplementaryViewForKind(.Header, inView: view, atIndex: validIndexPath)
         XCTAssertTrue(blockDidRun, "Configuration block was not run.")
     }
 
     func test_GivenRegisteredHeaderView_WhenAccessingFooter_ThatViewIsNotReturned() {
         var blockDidRun = false
-        registerHeaderWithKey("supplementary-key") { (_, _) in blockDidRun = true }
+        registerHeader { (_, _) in blockDidRun = true }
         let supplementary = factory.supplementaryViewForKind(.Footer, inView: view, atIndex: validIndexPath)
         XCTAssertNil(supplementary, "No view should be returned.")
         XCTAssertFalse(blockDidRun, "Configuration block should not have been run.")
     }
 
     func test_GivenRegisteredFooterView_WhenAccessingFooter_ThatViewIsReturned() {
-        registerFooterWithKey("supplementary-key") { (_, _) in }
+        registerFooter { (_, _) in }
         let supplementary = factory.supplementaryViewForKind(.Footer, inView: view, atIndex: validIndexPath)
         XCTAssertNotNil(supplementary, "View should be returned.")
     }
 
     func test_GivenRegisteredFooterView_WhenAccessingHeader_ThatViewIsNotReturned() {
         var blockDidRun = false
-        registerFooterWithKey("supplementary-key") { (_, _) in blockDidRun = true }
+        registerFooter { (_, _) in blockDidRun = true }
         let supplementary = factory.supplementaryViewForKind(.Header, inView: view, atIndex: validIndexPath)
         XCTAssertNil(supplementary, "No view should be returned.")
         XCTAssertFalse(blockDidRun, "Configuration block should not have been run.")
     }
 
     func test_GivenRegisteredCustomView_WhenAccessingCustomView_ThatViewIsReturned() {
-        factory.registerSupplementaryView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "sidebar"), kind: .Custom("Sidebar"), inView: view, withKey: "supplementary-key") { (_, _) in }
+        factory.registerSupplementaryView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "sidebar"), kind: .Custom("Sidebar"), inView: view) { (_, _) in }
         let supplementary = factory.supplementaryViewForKind(.Custom("Sidebar"), inView: view, atIndex: validIndexPath)
         XCTAssertNotNil(supplementary, "View should be returned.")
     }
 
     func test_GivenRegisteredCustomView_WhenAccessingDifferentCustomView_ThatViewIsNotReturned() {
         var blockDidRun = false
-        factory.registerSupplementaryView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "sidebar"), kind: .Custom("Left Sidebar"), inView: view, withKey: "supplementary-key") { (_, _) in blockDidRun = true }
+        factory.registerSupplementaryView(.ClassWithIdentifier(UITableViewHeaderFooterView.self, "sidebar"), kind: .Custom("Left Sidebar"), inView: view) { (_, _) in blockDidRun = true }
         let supplementary = factory.supplementaryViewForKind(.Custom("Right Sidebar"), inView: view, atIndex: validIndexPath)
         XCTAssertNil(supplementary, "No view should be returned.")
         XCTAssertFalse(blockDidRun, "Configuration block should not have been run.")
     }
+    
     // MARK: Helpers
 
-    func registerCellWithKey(key: String, config: Factory.CellConfiguration) {
-        factory.registerCell(.ClassWithIdentifier(UICollectionViewCell.self, "cell"), inView: view, withKey: key, configuration: config)
+    func registerCell(key: String? = .None, config: Factory.CellConfiguration) {
+        if let key = key {
+            factory.registerCell(.ClassWithIdentifier(UICollectionViewCell.self, "cell"), inView: view, withKey: key, configuration: config)
+        }
+        else {
+            factory.registerCell(.ClassWithIdentifier(UICollectionViewCell.self, "cell"), inView: view, configuration: config)
+        }
     }
 
-    func registerHeaderWithKey(key: String, config: Factory.SupplementaryViewConfiguration) {
-        factory.registerHeaderView(.ClassWithIdentifier(UICollectionReusableView.self, "header"), inView: view, withKey: key, configuration: config)
+    func registerHeader(key: String? = .None, config: Factory.SupplementaryViewConfiguration) {
+        if let key = key {
+            factory.registerHeaderView(.ClassWithIdentifier(UICollectionReusableView.self, "header"), inView: view, withKey: key, configuration: config)
+        }
+        else {
+            factory.registerHeaderView(.ClassWithIdentifier(UICollectionReusableView.self, "header"), inView: view, configuration: config)
+        }
     }
 
-    func registerFooterWithKey(key: String, config: Factory.SupplementaryViewConfiguration) {
-        factory.registerFooterView(.ClassWithIdentifier(UICollectionReusableView.self, "footer"), inView: view, withKey: key, configuration: config)
+    func registerFooter(key: String? = .None, config: Factory.SupplementaryViewConfiguration) {
+        if let key = key {
+            factory.registerFooterView(.ClassWithIdentifier(UICollectionReusableView.self, "footer"), inView: view, withKey: key, configuration: config)
+        }
+        else {
+            factory.registerFooterView(.ClassWithIdentifier(UICollectionReusableView.self, "footer"), inView: view, configuration: config)
+        }
     }
 }
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -10,16 +10,14 @@ PODS:
     - TaylorSource/Base
     - YapDatabase (~> 2.6)
     - YapDatabaseExtensions (~> 1)
-  - YapDatabase (2.6.1):
-    - YapDatabase/standard (= 2.6.1)
-  - YapDatabase/common (2.6.1):
+  - YapDatabase (2.6.2):
+    - YapDatabase/standard (= 2.6.2)
+  - YapDatabase/standard (2.6.2):
     - CocoaLumberjack (~> 1)
-  - YapDatabase/standard (2.6.1):
-    - YapDatabase/common
-  - YapDatabaseExtensions (1.2.2):
+  - YapDatabaseExtensions (1.3.0):
     - YapDatabase (~> 2.6)
-    - YapDatabaseExtensions/Common (= 1.2.2)
-  - YapDatabaseExtensions/Common (1.2.2):
+    - YapDatabaseExtensions/Common (= 1.3.0)
+  - YapDatabaseExtensions/Common (1.3.0):
     - YapDatabase (~> 2.6)
 
 DEPENDENCIES:
@@ -42,7 +40,7 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 628fca2e88ef06f7cf6817309aa405f325d9a6fa
   DateTools: b93a2c2017747329c6077c7d7e8a75106e23d0d7
   TaylorSource: eae71df0581b18c32f9a895d7a34d9150dac780d
-  YapDatabase: 13566c87dc9226a0f15d755edba08e8ad94cac9f
-  YapDatabaseExtensions: bd70e43e23df61a37a4ea4fcfd485d64d41cb608
+  YapDatabase: 2898ddb5dfbef699539a2a673bf900831f4eca8b
+  YapDatabaseExtensions: a0f232f023f1121666c1f11342195a627152d6e3
 
-COCOAPODS: 0.36.4
+COCOAPODS: 0.37.0

--- a/Pod/YapDatabase/YapDBPresentationFactory.swift
+++ b/Pod/YapDatabase/YapDBPresentationFactory.swift
@@ -25,15 +25,8 @@ public class YapDBFactory<
     where
     View: CellBasedView>: Factory<Item, Cell, SupplementaryView, View, YapDBCellIndex, YapDBSupplementaryIndex> {
 
-    public override init(cell: GetCellKey, supplementary: GetSupplementaryKey) {
+    public override init(cell: GetCellKey? = .None, supplementary: GetSupplementaryKey? = .None) {
         super.init(cell: cell, supplementary: supplementary)
-    }
-
-    public convenience init(cellKey: String, supplementaryKey: String) {
-        self.init(
-            cell: { (_, _) in cellKey },
-            supplementary: { _ in supplementaryKey }
-        )
     }
 }
 


### PR DESCRIPTION
Optimise the basic case where a factory only has one configuration block for each cell description. Meaning, that the cell key can be ignored completely.

i.e. `getCellKey` closure is optional, and cell registration has method without key.