### PR TITLE
Use DatasourceProviderType throughout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.11.0
+1. [[TAY-12](https://github.com/danthorpe/TaylorSource/pull/12)]: Modifies [TableView|CollectionView]DataSourceProviders to access arguments of DatasourceProviderType instead of DatasourceType. This allows for improved composition and code re-use.
+
+
 # 0.10.0
 1. [[TAY-5](https://github.com/danthorpe/TaylorSource/pull/5)]: Adopts Quick BDD testing framework, adds coverage to YapDB Observer & Datasource.
 1. [[TAY-7](https://github.com/danthorpe/TaylorSource/pull/7)]: Simplifies the common case of having a factory with a single cell type. In such a scenario, initialization of the Factory class requires no key closures, and cell/view registration takes no key parameter.

--- a/Example/Datasources/ViewController.swift
+++ b/Example/Datasources/ViewController.swift
@@ -65,8 +65,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var segmentedControl: UISegmentedControl!
 
-    var segmentedDatasource: SegmentedDatasource<EventsDatasource>!
-    var datasource: TableViewDataSourceProvider<SegmentedDatasource<EventsDatasource>>!
+    var segmentedDatasourceProvider: SegmentedDatasourceProvider<EventsDatasource>!
+    var datasource: TableViewDataSourceProvider<SegmentedDatasourceProvider<EventsDatasource>>!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -77,19 +77,19 @@ class ViewController: UIViewController {
         let colors: [Event.Color] = [.Red, .Blue, .Green]
         let datasources = colors.map { EventsDatasource(color: $0, db: database, view: self.tableView) }
 
-        segmentedDatasource = SegmentedDatasource(id: "events segmented datasource", datasources: datasources, selectedIndex: 0) { [weak self] in
+        segmentedDatasourceProvider = SegmentedDatasourceProvider(id: "events segmented datasource", datasources: datasources, selectedIndex: 0) { [weak self] in
             self?.tableView.reloadData()
         }
 
-        segmentedDatasource.configureSegmentedControl(segmentedControl)
+        segmentedDatasourceProvider.configureSegmentedControl(segmentedControl)
 
-        datasource = TableViewDataSourceProvider(segmentedDatasource)
+        datasource = TableViewDataSourceProvider(segmentedDatasourceProvider)
         tableView.dataSource = datasource.tableViewDataSource
     }
 
     @IBAction func addEvent(sender: UIBarButtonItem) {
-        let color = segmentedDatasource.selectedDatasourceProvider.eventColor
-        segmentedDatasource.selectedDatasourceProvider.addEvent(Event.create(color: color))
+        let color = segmentedDatasourceProvider.selectedDatasourceProvider.eventColor
+        segmentedDatasourceProvider.selectedDatasourceProvider.addEvent(Event.create(color: color))
     }
 
     @IBAction func refreshEvents(sender: UIBarButtonItem) {
@@ -97,7 +97,7 @@ class ViewController: UIViewController {
     }
 
     @IBAction func removeAll(sender: UIBarButtonItem) {
-        segmentedDatasource.selectedDatasourceProvider.removeAllEvents()
+        segmentedDatasourceProvider.selectedDatasourceProvider.removeAllEvents()
     }
 }
 

--- a/Pod/Base/Datasource.swift
+++ b/Pod/Base/Datasource.swift
@@ -263,7 +263,7 @@ public final class SegmentedDatasource<DatasourceProvider: DatasourceProviderTyp
 
     /// The currently selected datasource
     public var selectedDatasource: DatasourceProvider.Datasource {
-        return datasources[indexOfSelectedDatasource].datasource
+        return selectedDatasourceProvider.datasource
     }
 
     /// The currently selected datasource's title
@@ -276,15 +276,7 @@ public final class SegmentedDatasource<DatasourceProvider: DatasourceProviderTyp
         return selectedDatasource.factory
     }
 
-    /**
-    The initializer.
-
-    :param: id, a String identifier for the datasource.
-    :param: datasources, an array of DatasourceProvider instances.
-    :param: selectedIndex, the index of the initial selection.
-    :param: didSelectDatasourceCompletion, a completion block which executes when selecting the datasource has completed. This block should reload the view.
-    */
-    public init(id: String, datasources d: [DatasourceProvider], selectedIndex: Int = 0, didSelectDatasourceCompletion: UpdateBlock) {
+    init(id: String, datasources d: [DatasourceProvider], selectedIndex: Int = 0, didSelectDatasourceCompletion: UpdateBlock) {
         identifier = id
         datasources = d
         state = Protector(SegmentedDatasourceState(selectedIndex: selectedIndex))
@@ -302,6 +294,7 @@ public final class SegmentedDatasource<DatasourceProvider: DatasourceProviderTyp
     didSelectDatasourceCompletion completion block.
     
     :param: segmentedControl the UISegmentedControl to configure.
+    
     */
     public func configureSegmentedControl(segmentedControl: UISegmentedControl) {
         segmentedControl.removeAllSegments()
@@ -387,8 +380,50 @@ public final class SegmentedDatasource<DatasourceProvider: DatasourceProviderTyp
     }
 }
 
+public struct SegmentedDatasourceProvider<DatasourceProvider: DatasourceProviderType>: DatasourceProviderType {
+
+    public typealias UpdateBlock = () -> Void
+
+    public let datasource: SegmentedDatasource<DatasourceProvider>
 
 
+    /// The index of the currently selected datasource provider
+    public var indexOfSelectedDatasource: Int {
+        return datasource.indexOfSelectedDatasource
+    }
+
+    /// The currently selected datasource provider
+    public var selectedDatasourceProvider: DatasourceProvider {
+        return datasource.selectedDatasourceProvider
+    }
+
+    /// The currently selected datasource
+    public var selectedDatasource: DatasourceProvider.Datasource {
+        return datasource.selectedDatasource
+    }
+
+    /**
+    The initializer.
+
+    :param: id, a String identifier for the datasource.
+    :param: datasources, an array of DatasourceProvider instances.
+    :param: selectedIndex, the index of the initial selection.
+    :param: didSelectDatasourceCompletion, a completion block which executes when selecting the datasource has completed. This block should reload the view.
+    */
+    public init(id: String, datasources: [DatasourceProvider], selectedIndex: Int = 0, didSelectDatasourceCompletion: () -> Void) {
+        datasource = SegmentedDatasource(id: id, datasources: datasources, selectedIndex: selectedIndex, didSelectDatasourceCompletion: didSelectDatasourceCompletion)
+    }
+
+    /**
+    Call the equivalent function on SegmentedDatasource.
+
+    :param: segmentedControl the UISegmentedControl to configure.
+
+    */
+    public func configureSegmentedControl(segmentedControl: UISegmentedControl) {
+        datasource.configureSegmentedControl(segmentedControl)
+    }
+}
 
 
 

--- a/Pod/Base/Datasource.swift
+++ b/Pod/Base/Datasource.swift
@@ -97,6 +97,27 @@ public protocol DatasourceProviderType {
 }
 
 /**
+Simple wrapper for a Datasource. TaylorSource is designed for composing Datasources
+inside custom classes, referred to as *datasource providers*. There are Table View
+and Collection View data source generators which accept datasource providers.
+
+Therefore, if you absolutely don't want your own custom class to act as the datasource
+provider, this structure is available to easily wrap any DatasourceType. e.g.
+
+    let datasource: UITableViewDataSourceProvider<BasicDatasourceProvider<StaticDatasource>>
+    tableView.dataSource = datasource.tableViewDataSource
+*/
+public struct BasicDatasourceProvider<Datasource: DatasourceType>: DatasourceProviderType {
+
+    /// The wrapped Datasource
+    public let datasource: Datasource
+
+    init(_ d: Datasource) {
+        datasource = d
+    }
+}
+
+/**
 A concrete implementation of DatasourceType for simple immutable arrays of objects.
 The static datasource is initalized with the model items to display. They all 
 are in the same section.

--- a/Pod/Base/Views.swift
+++ b/Pod/Base/Views.swift
@@ -27,32 +27,37 @@ This architecture allows for different kinds of DatasourceType(s) to
 be used as the basic for a UITableViewDataSource, without the need
 to implement UITableViewDataSource on any of them.
 */
-public struct TableViewDataSourceProvider<Datasource where Datasource: DatasourceType, Datasource.FactoryType.ViewType: UITableViewType, Datasource.FactoryType.TextType == String>: UITableViewDataSourceProvider {
+public struct TableViewDataSourceProvider<DatasourceProvider where DatasourceProvider: DatasourceProviderType, DatasourceProvider.Datasource.FactoryType.ViewType: UITableViewType, DatasourceProvider.Datasource.FactoryType.TextType == String>: UITableViewDataSourceProvider {
 
-    typealias TableView = Datasource.FactoryType.ViewType
+    typealias TableView = DatasourceProvider.Datasource.FactoryType.ViewType
 
-    public let datasource: Datasource
-    public var factory: Datasource.FactoryType {
+    public let provider: DatasourceProvider
+
+    public var datasource: DatasourceProvider.Datasource {
+        return provider.datasource
+    }
+
+    public var factory: DatasourceProvider.Datasource.FactoryType {
         return datasource.factory
     }
     
     let bridgedTableViewDataSource: TableViewDataSource
 
     /// Initalizes with a Datasource instance.
-    public init(_ d: Datasource) {
-        datasource = d
+    public init(_ p: DatasourceProvider) {
+        provider = p
 
         bridgedTableViewDataSource = TableViewDataSource(
             numberOfSections: { (view) -> Int in
-                d.numberOfSections },
+                p.datasource.numberOfSections },
             numberOfRowsInSection: { (view, section) -> Int in
-                d.numberOfItemsInSection(section) },
+                p.datasource.numberOfItemsInSection(section) },
             cellForRowAtIndexPath: { (view, indexPath) -> UITableViewCell in
-                d.cellForItemInView(view as! TableView, atIndexPath: indexPath) as! UITableViewCell },
+                p.datasource.cellForItemInView(view as! TableView, atIndexPath: indexPath) as! UITableViewCell },
             titleForHeaderInSection: { (view, section) -> String? in
-                d.textForSupplementaryElementInView(view as! TableView, kind: .Header, atIndexPath: NSIndexPath(forRow: 0, inSection: section)) },
+                p.datasource.textForSupplementaryElementInView(view as! TableView, kind: .Header, atIndexPath: NSIndexPath(forRow: 0, inSection: section)) },
             titleForFooterInSection: { (view, section) -> String? in
-                d.textForSupplementaryElementInView(view as! TableView, kind: .Footer, atIndexPath: NSIndexPath(forRow: 0, inSection: section)) }
+                p.datasource.textForSupplementaryElementInView(view as! TableView, kind: .Footer, atIndexPath: NSIndexPath(forRow: 0, inSection: section)) }
         )
     }
 
@@ -122,25 +127,26 @@ to construct and a bridging class which implements UICollectionViewDataSource.
 
 The ViewType of the Datasource's Factory is constrained to be a UICollectionViewType
 */
-public struct CollectionViewDataSourceProvider<Datasource where Datasource: DatasourceType, Datasource.FactoryType.ViewType: UICollectionViewType>: UICollectionViewDataSourceProvider {
+public struct CollectionViewDataSourceProvider<DatasourceProvider where DatasourceProvider: DatasourceProviderType, DatasourceProvider.Datasource.FactoryType.ViewType: UICollectionViewType>: UICollectionViewDataSourceProvider {
 
-    typealias CollectionView = Datasource.FactoryType.ViewType
+    typealias CollectionView = DatasourceProvider.Datasource.FactoryType.ViewType
 
-    let datasource: Datasource
+    let provider: DatasourceProvider
+
     let bridgedDataSource: CollectionViewDataSource
 
     /// Initializes with a Datasource instance
-    public init(_ d: Datasource) {
-        datasource = d
+    public init(_ p: DatasourceProvider) {
+        provider = p
         bridgedDataSource = CollectionViewDataSource(
             numberOfSections: { (view) -> Int in
-                d.numberOfSections },
+                p.datasource.numberOfSections },
             numberOfItemsInSection: { (view, section) -> Int in
-                d.numberOfItemsInSection(section) },
+                p.datasource.numberOfItemsInSection(section) },
             cellForItemAtIndexPath: { (view, indexPath) -> UICollectionViewCell in
-                d.cellForItemInView(view as! CollectionView, atIndexPath: indexPath) as! UICollectionViewCell },
+                p.datasource.cellForItemInView(view as! CollectionView, atIndexPath: indexPath) as! UICollectionViewCell },
             viewForElementKindAtIndexPath: { (view, indexPath, element) -> UICollectionReusableView in
-                d.viewForSupplementaryElementInView(view as! CollectionView, kind: SupplementaryElementKind(element), atIndexPath: indexPath) as! UICollectionReusableView }
+                p.datasource.viewForSupplementaryElementInView(view as! CollectionView, kind: SupplementaryElementKind(element), atIndexPath: indexPath) as! UICollectionReusableView }
         )
     }
 


### PR DESCRIPTION
At the moment `SegmentedDatasource` uses `DatasourceProviderType`, but Table View and Collection View do not. So, it's not that easy to compose datasources correctly. The desired behaviour we're looking for is that the user composes a `DatasourceType` inside their own class, and then creates a say a `TableViewDataSourceProvider` with this. Their type only needs to confirm to `DatasourceProviderType`.