### PR TITLE
Make it easier to create purely custom DatasourceType objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.12.0
+1. [[TAY-13](https://github.com/danthorpe/TaylorSource/pull/13)]: Make a few subtle changes to increase the ease of implementing DatasourceType from scratch outside of TaylorSource. No longer is a SequenceType and CollectionType implementation required. And `YapDBCellIndex` and `YapDBSupplementaryViewIndex` have public constructors.
+
+
 # 0.11.0
 1. [[TAY-12](https://github.com/danthorpe/TaylorSource/pull/12)]: Modifies [TableView|CollectionView]DataSourceProviders to access arguments of DatasourceProviderType instead of DatasourceType. This allows for improved composition and code re-use.
 

--- a/Pod/Base/Datasource.swift
+++ b/Pod/Base/Datasource.swift
@@ -21,7 +21,7 @@ This protocol exists to allow for the definition of different kinds of
 datasources. Coupled with DatasourceProviderType, datasources can be
 composed and extended with ease. See SegmentedDatasource for example.
 */
-public protocol DatasourceType: SequenceType, CollectionType {
+public protocol DatasourceType {
     typealias FactoryType: _FactoryType
 
     /// Access the factory from the datasource, likely should be a stored property.
@@ -131,7 +131,7 @@ public final class StaticDatasource<
     where
     Factory: _FactoryType,
     Factory.CellIndexType == NSIndexPath,
-    Factory.SupplementaryIndexType == NSIndexPath>: DatasourceType {
+    Factory.SupplementaryIndexType == NSIndexPath>: DatasourceType, SequenceType, CollectionType {
 
     typealias FactoryType = Factory
 

--- a/Pod/YapDatabase/YapDBDatasource.swift
+++ b/Pod/YapDatabase/YapDBDatasource.swift
@@ -13,7 +13,7 @@ public struct YapDBDatasource<
     Factory.ViewType: UpdatableView,
     Factory.ViewType.ProcessChangesType == YapDatabaseViewMappings.Changes,
     Factory.CellIndexType == YapDBCellIndex,
-    Factory.SupplementaryIndexType == YapDBSupplementaryIndex>: DatasourceType {
+    Factory.SupplementaryIndexType == YapDBSupplementaryIndex>: DatasourceType, SequenceType, CollectionType {
 
     typealias FactoryType = Factory
 

--- a/Pod/YapDatabase/YapDBPresentationFactory.swift
+++ b/Pod/YapDatabase/YapDBPresentationFactory.swift
@@ -12,12 +12,23 @@ public protocol UpdatableView {
 public struct YapDBCellIndex: IndexPathIndexType {
     public let indexPath: NSIndexPath
     public let transaction: YapDatabaseReadTransaction
+
+    public init(indexPath: NSIndexPath, transaction: YapDatabaseReadTransaction) {
+        self.indexPath = indexPath
+        self.transaction = transaction
+    }
 }
 
 public struct YapDBSupplementaryIndex: IndexPathIndexType {
     public let group: String
     public let indexPath: NSIndexPath
     public let transaction: YapDatabaseReadTransaction
+
+    public init(group: String, indexPath: NSIndexPath, transaction: YapDatabaseReadTransaction) {
+        self.group = group
+        self.indexPath = indexPath
+        self.transaction = transaction
+    }
 }
 
 public class YapDBFactory<


### PR DESCRIPTION
Implementing DatasourceType outside of TayorSource could be made easier.

- [x] Expose constructors to `YapDBCellIndex` etc
- [x] DatasourceType does not need to extended SequenceType or CollectionType - they can be implemented separately on YapDBDatasource. 