### PR TITLE
Support slices in Observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.14.0
 1. [[TAY-18](https://github.com/danthorpe/TaylorSource/pull/18)]: Supports the optional editing methods in `UITableViewDataSource` via optional closures in `DatasourceProviderType`.
+2. [[TAY-20](https://github.com/danthorpe/TaylorSource/pull/20)]: Supports Sliceable on Observer, Mapper and YapDatabaseViewMappings.
 
 # 0.13.0
 1. [[TAY-17](https://github.com/danthorpe/TaylorSource/pull/17)]: Added a bitter badge to the README.

--- a/examples/Events/Datasources/Models.swift
+++ b/examples/Events/Datasources/Models.swift
@@ -20,7 +20,7 @@ public struct Event {
     let color: Color
     let date: NSDate
 
-    public init(uuid u: String, color c: Color, date d: NSDate) {
+    public init(uuid u: String = NSUUID().UUIDString, color c: Color, date d: NSDate = NSDate()) {
         uuid = u
         date = d
         color = c
@@ -145,6 +145,15 @@ public class EventArchiver: NSObject, NSCoding, Archiver {
         aCoder.encodeObject(value.color.archive, forKey: "color")
         aCoder.encodeObject(value.uuid, forKey: "uuid")
         aCoder.encodeObject(value.date, forKey: "date")
+    }
+}
+
+func createSomeEvents(numberOfDays: Int = 10) -> [Event] {
+    let today = NSDate()
+    let interval: NSTimeInterval = 86_400
+    return (0..<numberOfDays).map { index in
+        let date = today.dateByAddingTimeInterval(-1.0 * Double(index) * interval)
+        return Event(color: .Red, date: date)
     }
 }
 

--- a/framework/TaylorSource/YapDatabase/YapDB.swift
+++ b/framework/TaylorSource/YapDatabase/YapDB.swift
@@ -45,7 +45,7 @@ It implements SequenceType, and Int based CollectionType.
 
 It has an NSIndexPath based API for accessing items.
 */
-public struct Mapper<T>: SequenceType, CollectionType {
+public struct Mapper<T>: SequenceType, CollectionType, Sliceable {
 
     let readOnlyConnection: YapDatabaseConnection
     var configuration: Configuration<T>
@@ -69,6 +69,10 @@ public struct Mapper<T>: SequenceType, CollectionType {
 
     public subscript(i: Int) -> T {
         return itemAtIndexPath(mappings[i])!
+    }
+
+    public subscript(bounds: Range<Int>) -> [T] {
+        return mappings[bounds].map { self.itemAtIndexPath($0)! }
     }
 
     /**
@@ -353,6 +357,13 @@ extension Observer: CollectionType {
     }
 }
 
+extension Observer: Sliceable {
+
+    public subscript(bounds: Range<Int>) -> [T] {
+        return mapper[bounds]
+    }
+}
+
 extension YapDatabaseViewMappings {
 
     /**
@@ -429,4 +440,18 @@ extension YapDatabaseViewMappings: CollectionType {
         }
     }
 }
+
+extension YapDatabaseViewMappings: Sliceable {
+
+    public subscript(bounds: Range<Int>) -> [NSIndexPath] {
+        return reduce(bounds, Array<NSIndexPath>()) { (var acc, index) in
+            acc.append(self[index])
+            return acc
+        }
+    }
+}
+
+
+
+
 

--- a/framework/TaylorSource/YapDatabase/YapDB.swift
+++ b/framework/TaylorSource/YapDatabase/YapDB.swift
@@ -451,7 +451,3 @@ extension YapDatabaseViewMappings: Sliceable {
     }
 }
 
-
-
-
-

--- a/framework/TaylorSourceTests/YapDBMapperTests.swift
+++ b/framework/TaylorSourceTests/YapDBMapperTests.swift
@@ -45,4 +45,13 @@ class MapperTests: XCTestCase {
         mapper = Mapper(database: db, configuration: events())
         XCTAssertEqual(mapper.indexPathForKey(keyForPersistable(event), inCollection: Event.collection)!, NSIndexPath.first)
     }
+
+    func test__when_database_has_three_events__can_slice_last_two() {
+        let someEvents = createSomeEvents()
+        db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__) { db in
+            db.write(someEvents)
+        }
+        mapper = Mapper(database: db, configuration: events())
+        XCTAssertEqual(Array(reverse(someEvents)[2..<5]), mapper[2..<5])
+    }
 }


### PR DESCRIPTION
An Observer should be able to work very similarly to an array. A key piece of missing functionality for this is subscripting with a range.

```swift
subscript(range: Range<Int>) -> Slice<T> { }
```

I've actually implemented it as...

```swift
subscript(range: Range<Int>) -> [T] { }
```