### PR TITLE
Refactor Datasource Provider Type's editor functionality.

### DIFF
--- a/framework/TaylorSource/Base/Views.swift
+++ b/framework/TaylorSource/Base/Views.swift
@@ -51,26 +51,26 @@ public struct TableViewDataSourceProvider<
     public init(_ p: DatasourceProvider) {
         provider = p
 
-        if  p.canEditItemAtIndexPath != nil &&
-            p.commitEditActionForItemAtIndexPath != nil &&
-            p.canMoveItemAtIndexPath != nil &&
-            p.commitMoveItemAtIndexPathToIndexPath != nil {
+        if  p.editor.canEditItemAtIndexPath != nil &&
+            p.editor.commitEditActionForItemAtIndexPath != nil &&
+            p.editor.canMoveItemAtIndexPath != nil &&
+            p.editor.commitMoveItemAtIndexPathToIndexPath != nil {
 
                 bridgedTableViewDataSource = TableViewDataSource.Editable(
                     EditableTableViewDataSource(
                         canEditRowAtIndexPath: { (_, indexPath) -> Bool in
-                            p.canEditItemAtIndexPath!(indexPath: indexPath)
+                            p.editor.canEditItemAtIndexPath!(indexPath: indexPath)
                         },
                         commitEditingStyleForRowAtIndexPath: { (_, editingStyle, indexPath) -> Void in
                             if let action = EditableDatasourceAction(editingStyle: editingStyle) {
-                                p.commitEditActionForItemAtIndexPath!(action: action, indexPath: indexPath)
+                                p.editor.commitEditActionForItemAtIndexPath!(action: action, indexPath: indexPath)
                             }
                         },
                         canMoveRowAtIndexPath: { (_, indexPath) -> Bool in
-                            p.canMoveItemAtIndexPath!(indexPath: indexPath)
+                            p.editor.canMoveItemAtIndexPath!(indexPath: indexPath)
                         },
                         moveRowAtIndexPathToIndexPath: { (_, from, to) -> Void in
-                            p.commitMoveItemAtIndexPathToIndexPath!(from: from, to: to)
+                            p.editor.commitMoveItemAtIndexPathToIndexPath!(from: from, to: to)
                         },
                         numberOfSections: { _ -> Int in
                             p.datasource.numberOfSections },

--- a/framework/TaylorSourceTests/DatasourceProviderTests.swift
+++ b/framework/TaylorSourceTests/DatasourceProviderTests.swift
@@ -17,12 +17,7 @@ class DatasourceProviderTests: XCTestCase {
         typealias Datasource = StaticDatasource<Factory>
 
         let datasource: Datasource
-        let canEditItemAtIndexPath: CanEditItemAtIndexPath?
-        let commitEditActionForItemAtIndexPath: CommitEditActionForItemAtIndexPath?
-        let canMoveItemAtIndexPath: CanMoveItemAtIndexPath?
-        let commitMoveItemAtIndexPathToIndexPath: CommitMoveItemAtIndexPathToIndexPath?
-
-        let editActionForItemAtIndexPath: EditActionForItemAtIndexPath?
+        let editor: Editor
 
         init(
             data: [Event],
@@ -33,12 +28,7 @@ class DatasourceProviderTests: XCTestCase {
             editAction: EditActionForItemAtIndexPath? = .None) {
 
                 datasource = Datasource(id: "test", factory: Factory(), items: data)
-
-                canEditItemAtIndexPath = canEdit
-                commitEditActionForItemAtIndexPath = commitEdit
-                canMoveItemAtIndexPath = canMove
-                commitMoveItemAtIndexPathToIndexPath = commitMove
-                editActionForItemAtIndexPath = editAction
+                editor = Editor(canEdit: canEdit, commitEdit: commitEdit, editAction: editAction, canMove: canMove, commitMove: commitMove)
         }
     }
 


### PR DESCRIPTION
I can't wait for Swift 2.0 - need to reduce these optional variables into a single one.