### PR TITLE
Add support for managing table view selections.

### DIFF
--- a/framework/TaylorSource.xcodeproj/project.pbxproj
+++ b/framework/TaylorSource.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		6584D5681B69620F003B8666 /* EntityDatasourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6584D5671B69620F003B8666 /* EntityDatasourceTests.swift */; };
 		65AC884A1B54468300BFF702 /* DatasourceProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AC88491B54468300BFF702 /* DatasourceProviderTests.swift */; };
 		65AFECE81B6ACED100716BB5 /* YapDBEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AFECE71B6ACED100716BB5 /* YapDBEntity.swift */; };
+		65D78F361B824E760001E7A6 /* Selection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D78F351B824E760001E7A6 /* Selection.swift */; };
 		65F8E6F51B694AB9009C18F9 /* Basic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F8E6F41B694AB9009C18F9 /* Basic.swift */; };
 		65F8E6F71B694B07009C18F9 /* Segmented.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F8E6F61B694B07009C18F9 /* Segmented.swift */; };
 		65F8E6F91B694B62009C18F9 /* Entity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F8E6F81B694B62009C18F9 /* Entity.swift */; };
@@ -69,6 +70,7 @@
 		6584D5671B69620F003B8666 /* EntityDatasourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EntityDatasourceTests.swift; sourceTree = "<group>"; };
 		65AC88491B54468300BFF702 /* DatasourceProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatasourceProviderTests.swift; sourceTree = "<group>"; };
 		65AFECE71B6ACED100716BB5 /* YapDBEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YapDBEntity.swift; sourceTree = "<group>"; };
+		65D78F351B824E760001E7A6 /* Selection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Selection.swift; sourceTree = "<group>"; };
 		65F8E6F41B694AB9009C18F9 /* Basic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Basic.swift; sourceTree = "<group>"; };
 		65F8E6F61B694B07009C18F9 /* Segmented.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Segmented.swift; sourceTree = "<group>"; };
 		65F8E6F81B694B62009C18F9 /* Entity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Entity.swift; sourceTree = "<group>"; };
@@ -187,13 +189,14 @@
 		652DB7841B2879EE0002F65C /* Base */ = {
 			isa = PBXGroup;
 			children = (
+				65F8E6F41B694AB9009C18F9 /* Basic.swift */,
 				652DB7851B2879EE0002F65C /* Datasource.swift */,
+				65F8E6F81B694B62009C18F9 /* Entity.swift */,
 				652DB7861B2879EE0002F65C /* Factory.swift */,
+				65F8E6F61B694B07009C18F9 /* Segmented.swift */,
+				65D78F351B824E760001E7A6 /* Selection.swift */,
 				652DB78B1B2879EE0002F65C /* Utilities.swift */,
 				652DB78C1B2879EE0002F65C /* Views.swift */,
-				65F8E6F41B694AB9009C18F9 /* Basic.swift */,
-				65F8E6F61B694B07009C18F9 /* Segmented.swift */,
-				65F8E6F81B694B62009C18F9 /* Entity.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -397,6 +400,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				65D78F361B824E760001E7A6 /* Selection.swift in Sources */,
 				652DB78F1B2879EE0002F65C /* YapDBFactory.swift in Sources */,
 				652DB78D1B2879EE0002F65C /* YapDB.swift in Sources */,
 				65F8E6F71B694B07009C18F9 /* Segmented.swift in Sources */,

--- a/framework/TaylorSource/Base/Basic.swift
+++ b/framework/TaylorSource/Base/Basic.swift
@@ -49,8 +49,9 @@ public final class StaticDatasource<
 
     typealias FactoryType = Factory
 
-    public let identifier: String
     public let factory: Factory
+    public let selectionManager = SelectionManager()
+    public let identifier: String
     public var title: String? = .None
     private var items: [Factory.ItemType]
 

--- a/framework/TaylorSource/Base/Datasource.swift
+++ b/framework/TaylorSource/Base/Datasource.swift
@@ -27,6 +27,9 @@ public protocol DatasourceType {
     /// Access the factory from the datasource, likely should be a stored property.
     var factory: FactoryType { get }
 
+    /// A selection manager
+    var selectionManager: SelectionManager { get }
+
     /// An identifier which is primarily to ease debugging and logging.
     var identifier: String { get }
 

--- a/framework/TaylorSource/Base/Entity.swift
+++ b/framework/TaylorSource/Base/Entity.swift
@@ -29,8 +29,9 @@ public struct EntityDatasource<
 
     typealias FactoryType = Factory
 
-    public let identifier: String
     public let factory: Factory
+    public let selectionManager = SelectionManager()
+    public let identifier: String
     public var title: String? = .None
     public private(set) var entity: Entity
 

--- a/framework/TaylorSource/Base/Segmented.swift
+++ b/framework/TaylorSource/Base/Segmented.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct SegmentedDatasourceState {
+struct SegmentedState {
     var selectedIndex: Int = 0
 }
 
@@ -24,14 +24,15 @@ types, e.g. model type. However, typical usage would involve using the tabs to
 filter the same type of objects with some other metric. See the Example project.
 
 */
-public final class SegmentedDatasource<DatasourceProvider: DatasourceProviderType>: DatasourceType {
+public final class SegmentedDatasource<DatasourceProvider: DatasourceProviderType>: DatasourceType, SequenceType, CollectionType {
 
     public typealias UpdateBlock = () -> Void
 
-    private let state: Protector<SegmentedDatasourceState>
-    internal let update: UpdateBlock?
-    internal let datasources: [DatasourceProvider]
+    private let state: Protector<SegmentedState>
     private var valueChangedHandler: TargetActionHandler? = .None
+    internal let update: UpdateBlock?
+
+    public let datasources: [DatasourceProvider]
 
     public let identifier: String
 
@@ -52,20 +53,25 @@ public final class SegmentedDatasource<DatasourceProvider: DatasourceProviderTyp
         return selectedDatasourceProvider.datasource
     }
 
-    /// The currently selected datasource's title
-    public var title: String? {
-        return selectedDatasource.title
-    }
-
     /// The currently selected datasource's factory
     public var factory: DatasourceProvider.Datasource.FactoryType {
         return selectedDatasource.factory
     }
 
+    /// The currently selected selection manager
+    public var selectionManager: SelectionManager {
+        return selectedDatasource.selectionManager
+    }
+
+    /// The currently selected datasource's title
+    public var title: String? {
+        return selectedDatasource.title
+    }
+
     init(id: String, datasources d: [DatasourceProvider], selectedIndex: Int = 0, didSelectDatasourceCompletion: UpdateBlock) {
         identifier = id
         datasources = d
-        state = Protector(SegmentedDatasourceState(selectedIndex: selectedIndex))
+        state = Protector(SegmentedState(selectedIndex: selectedIndex))
         update = didSelectDatasourceCompletion
     }
 
@@ -106,9 +112,9 @@ public final class SegmentedDatasource<DatasourceProvider: DatasourceProviderTyp
         precondition(0 <= index, "Index must be greater than zero.")
         precondition(index < datasources.count, "Index must be less than maximum number of datasources.")
 
-        state.write({ (inout state: SegmentedDatasourceState) in
+        state.write({ (inout state: SegmentedState) in
             state.selectedIndex = index
-            }, completion: update)
+        }, completion: update)
     }
 
     func selectedSegmentedIndexDidChange(sender: AnyObject?) {
@@ -212,6 +218,8 @@ public struct SegmentedDatasourceProvider<DatasourceProvider: DatasourceProvider
     public func configureSegmentedControl(segmentedControl: UISegmentedControl) {
         datasource.configureSegmentedControl(segmentedControl)
     }
+
 }
+
 
 

--- a/framework/TaylorSource/Base/Selection.swift
+++ b/framework/TaylorSource/Base/Selection.swift
@@ -1,0 +1,48 @@
+//
+//  Selection.swift
+//  TaylorSource
+//
+//  Created by Daniel Thorpe on 17/08/2015.
+//  Copyright (c) 2015 Daniel Thorpe. All rights reserved.
+//
+
+import Foundation
+
+public class SelectionManager {
+
+    var selectedIndexPaths = Set<NSIndexPath>()
+
+    public var allowsMultipleSelection: Bool = false
+    public var enabled = false
+
+    public init() { }
+
+    public func addIndexPath(indexPath: NSIndexPath) {
+        selectedIndexPaths.insert(indexPath)
+    }
+
+    public func removeIndexPath(indexPath: NSIndexPath) {
+        selectedIndexPaths.remove(indexPath)
+    }
+
+    public func contains(itemAtIndexPath indexPath: NSIndexPath) -> Bool {
+        return selectedIndexPaths.contains(indexPath)
+    }
+
+    public func selectItemAtIndexPath(indexPath: NSIndexPath, shouldRefreshItems: ((indexPathsToRefresh: [NSIndexPath]) -> Void)? = .None) {
+        enabled = true
+        var itemsToUpdate = Set(arrayLiteral: indexPath)
+        if contains(itemAtIndexPath: indexPath) {
+            removeIndexPath(indexPath)
+        }
+        else {
+            if !allowsMultipleSelection {
+                itemsToUpdate.unionInPlace(selectedIndexPaths)
+                selectedIndexPaths.removeAll(keepCapacity: false)
+            }
+            addIndexPath(indexPath)
+        }
+        shouldRefreshItems?(indexPathsToRefresh: Array(itemsToUpdate))
+    }
+}
+

--- a/framework/TaylorSource/YapDatabase/YapDBDatasource.swift
+++ b/framework/TaylorSource/YapDatabase/YapDBDatasource.swift
@@ -22,6 +22,7 @@ public struct YapDBDatasource<
     public var title: String? = .None
 
     public let observer: Observer<Factory.ItemType>
+    public var selectionManager = SelectionManager()
 
     var mappings: YapDatabaseViewMappings {
         return observer.mappings
@@ -54,9 +55,10 @@ public struct YapDBDatasource<
     }
 
     public func cellForItemInView(view: Factory.ViewType, atIndexPath indexPath: NSIndexPath) -> Factory.CellType {
+        let isSelected: Bool = selectionManager.enabled && selectionManager.contains(itemAtIndexPath: indexPath)
         return readOnlyConnection.read { transaction in
             if let item = self.observer.itemAtIndexPath(indexPath, inTransaction: transaction) {
-                let index = YapDBCellIndex(indexPath: indexPath, transaction: transaction)
+                let index = YapDBCellIndex(indexPath: indexPath, transaction: transaction, isSelected: isSelected)
                 return self.factory.cellForItem(item, inView: view, atIndex: index)
             }
             fatalError("No item available at index path: \(indexPath)")

--- a/framework/TaylorSource/YapDatabase/YapDBDatasource.swift
+++ b/framework/TaylorSource/YapDatabase/YapDBDatasource.swift
@@ -21,7 +21,7 @@ public struct YapDBDatasource<
     public let factory: Factory
     public var title: String? = .None
 
-    private let observer: Observer<Factory.ItemType>
+    public let observer: Observer<Factory.ItemType>
 
     var mappings: YapDatabaseViewMappings {
         return observer.mappings

--- a/framework/TaylorSource/YapDatabase/YapDBEntity.swift
+++ b/framework/TaylorSource/YapDatabase/YapDBEntity.swift
@@ -22,8 +22,9 @@ public struct YapDBEntityDatasource<
 
     typealias FactoryType = Factory
 
-    public let identifier: String
     public let factory: Factory
+    public let identifier: String
+    public let selectionManager = SelectionManager()
     public var title: String? = .None
     public private(set) var entity: Entity
 

--- a/framework/TaylorSource/YapDatabase/YapDBFactory.swift
+++ b/framework/TaylorSource/YapDatabase/YapDBFactory.swift
@@ -12,10 +12,12 @@ public protocol UpdatableView {
 public struct YapDBCellIndex: IndexPathIndexType {
     public let indexPath: NSIndexPath
     public let transaction: YapDatabaseReadTransaction
+    public let isSelected: Bool?
 
-    public init(indexPath: NSIndexPath, transaction: YapDatabaseReadTransaction) {
+    public init(indexPath: NSIndexPath, transaction: YapDatabaseReadTransaction, isSelected: Bool? = .None) {
         self.indexPath = indexPath
         self.transaction = transaction
+        self.isSelected = isSelected
     }
 }
 

--- a/framework/TaylorSourceTests/YapDBDatasourceTests.swift
+++ b/framework/TaylorSourceTests/YapDBDatasourceTests.swift
@@ -70,7 +70,7 @@ extension YapDBDatasourceTests {
         XCTAssertEqual(datasource.numberOfItemsInSection(1), numberOfBlueEvents)
     }
 
-    func test_GivenStaticDatasource_WhenAccessingItemsAtANegativeIndex_ThatResultIsNone() {
+    func test_GivenDatasource_WhenAccessingItemsAtANegativeIndex_ThatResultIsNone() {
         var numberOfEvents: Int!
         let db = createYapDatabase(__FILE__, suffix: __FUNCTION__) { database in
             numberOfEvents = database.write(createManyEvents()).count
@@ -79,7 +79,7 @@ extension YapDBDatasourceTests {
         XCTAssertTrue(datasource.itemAtIndexPath(NSIndexPath(forRow: numberOfEvents * -1, inSection: 0)) == nil)
     }
 
-    func test_GivenStaticDatasource_WhenAccessingItemsGreaterThanMaxIndex_ThatResultIsNone() {
+    func test_GivenDatasource_WhenAccessingItemsGreaterThanMaxIndex_ThatResultIsNone() {
         var numberOfEvents: Int!
         let db = createYapDatabase(__FILE__, suffix: __FUNCTION__) { database in
             numberOfEvents = database.write(createManyEvents()).count
@@ -88,7 +88,7 @@ extension YapDBDatasourceTests {
         XCTAssertTrue(datasource.itemAtIndexPath(NSIndexPath(forRow: numberOfEvents * -1, inSection: 0)) == nil)
     }
 
-    func test_GivenStaticDatasource_WhenAccessingItems_ThatCorrectItemIsReturned() {
+    func test_GivenDatasource_WhenAccessingItems_ThatCorrectItemIsReturned() {
         var events: [Event]!
         let db = createYapDatabase(__FILE__, suffix: __FUNCTION__) { database in
             events = database.write(createManyEvents())


### PR DESCRIPTION
i.e. the datasource owns a "selection manager" which can be used to 

- [x] collect the set of NSIndexPath which have been selected.
- [x] simple function to abstract the nitty-gritty details of selection & deselection
- [x] single or multiple item selection
- [x] running an update block when the set changes - i.e. typically used to enable/disable a button
- [x] provide easy access in the cell index item, so a cell configuration block easily knows if that item is selected.