### PR TITLE
MapperTests compile again

### DIFF
--- a/TaylorSourceTests/YapDBMapperTests.swift
+++ b/TaylorSourceTests/YapDBMapperTests.swift
@@ -24,7 +24,7 @@ class MapperTests: XCTestCase {
 
     func test__when_database_has_one_item__initially__the_endIndex_is_1() {
         db = YapDB.testDatabase()
-        db.newConnection().write(Event.create(.Red))
+        db.newConnection().write(Event.create(color: .Red))
         mapper = Mapper(database: db, configuration: events())
         XCTAssertEqual(mapper.startIndex, 0)
         XCTAssertEqual(mapper.endIndex, 1)
@@ -32,7 +32,7 @@ class MapperTests: XCTestCase {
 
     func test__when_database_has_one_item__lookup_items_by_indexPath__the_first_indexPath__is_the_item() {
         db = YapDB.testDatabase()
-        let event = Event.create(.Red)
+        let event = Event.create(color: .Red)
         db.newConnection().write(event)
         mapper = Mapper(database: db, configuration: events())
         XCTAssertEqual(mapper.itemAtIndexPath(NSIndexPath.first)!, event)
@@ -40,7 +40,7 @@ class MapperTests: XCTestCase {
 
     func test__when_database_has_one_item__reverse_loop_items__the_first_item__is_the_first_indexPath() {
         db = YapDB.testDatabase()
-        let event = Event.create(.Red)
+        let event = Event.create(color: .Red)
         db.newConnection().write(event)
         mapper = Mapper(database: db, configuration: events())
         XCTAssertEqual(mapper.indexPathForKey(keyForPersistable(event), inCollection: Event.collection)!, NSIndexPath.first)


### PR DESCRIPTION
Missing `color` label in `Event` constructor.
