### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://badge.buildkite.com/2110c7f551cf50f252b3c1e998a163d21008d0deb1011ccd53.svg)](https://buildkite.com/blindingskies/taylorsource?branch=development)
 [![codecov.io](https://codecov.io/github/danthorpe/TaylorSource/coverage.svg?branch=development)](https://codecov.io/github/danthorpe/TaylorSource?branch=development)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/TaylorSource.svg)](https://img.shields.io/cocoapods/v/TaylorSource.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/TaylorSource.svg)](https://img.shields.io/cocoapods/v/TaylorSource.svg)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Platform](https://img.shields.io/cocoapods/p/TaylorSource.svg?style=flat)](http://cocoadocs.org/docsets/TaylorSource)
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
