### PR TITLE
Support for triggering a full view update through NSFRCUpdateHandler.

### DIFF
--- a/Sources/CoreData/NSFRCUpdateHandler.swift
+++ b/Sources/CoreData/NSFRCUpdateHandler.swift
@@ -48,7 +48,11 @@ public class NSFRCUpdateHandler: NSObject, NSFetchedResultsControllerDelegate {
     public func addUpdateObserver(observer: NSFRCIndexedUpdateConsumer) {
         observers.append(WeakObserver(observer))
     }
-    
+
+    public func sendFullUpdate() {
+        sendUpdate(.FullUpdate)
+    }
+
     private func sendUpdate(update: NSFRCIndexedUpdate) {
         observers = observers.filter { $0.value != nil } // Remove orphaned observers
         observers.forEach { $0.value?.handleIndexedUpdate(update) }


### PR DESCRIPTION
This functionality is needed to make it possible to replace the predicate of the `NSFetchRequest` driving the `NSFetchedResultsController`, for instance when implementing a search feature. Changes to the fetch request demands that NSFRC's `performFetch()` is called anew, which in turn must be followed by a full `reloadData()` of the UITable- or UICollectionView it drives.
