### PR TITLE
Fix warnings present in Xcode 7.3

### DIFF
--- a/Sources/Base/Datasource.swift
+++ b/Sources/Base/Datasource.swift
@@ -22,7 +22,7 @@ datasources. Coupled with DatasourceProviderType, datasources can be
 composed and extended with ease. See SegmentedDatasource for example.
 */
 public protocol DatasourceType {
-    typealias FactoryType: _FactoryType
+    associatedtype FactoryType: _FactoryType
 
     /// Access the factory from the datasource, likely should be a stored property.
     var factory: FactoryType { get }
@@ -129,8 +129,8 @@ the view controller initalizes and owns.
 */
 public protocol DatasourceProviderType {
 
-    typealias Datasource: DatasourceType
-    typealias Editor: DatasourceEditorType
+    associatedtype Datasource: DatasourceType
+    associatedtype Editor: DatasourceEditorType
 
     /// The underlying Datasource.
     var datasource: Datasource { get }

--- a/Sources/Base/Entity.swift
+++ b/Sources/Base/Entity.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol EntityType {
-    typealias ItemType
+    associatedtype ItemType
 
     var numberOfSections: Int { get }
 

--- a/Sources/Base/Factory.swift
+++ b/Sources/Base/Factory.swift
@@ -65,7 +65,7 @@ TaylorSource has implementations for UITableView and UICollectionView.
 public protocol ReusableCellBasedView: class {
 
     /// The generic type of the Cell.
-    typealias CellType
+    associatedtype CellType
 
     /**
     Registers a nib in the view.
@@ -96,7 +96,7 @@ public protocol ReusableCellBasedView: class {
 public protocol ReusableSupplementaryViewBasedView: class {
 
     /// The generic type of the SupplementaryView.
-    typealias SupplementaryViewType
+    associatedtype SupplementaryViewType
 
     /**
     Registers a nib in the view for a supplementary element kind, with a reuse identifier.
@@ -161,24 +161,24 @@ parameter of the configuration blocks to be generic.
 */
 public protocol _FactoryType {
 
-    typealias ItemType
-    typealias CellType
-    typealias SupplementaryViewType
-    typealias ViewType: CellBasedView
-    typealias CellIndexType: IndexPathIndexType
-    typealias SupplementaryIndexType: IndexPathIndexType
+    associatedtype ItemType
+    associatedtype CellType
+    associatedtype SupplementaryViewType
+    associatedtype ViewType: CellBasedView
+    associatedtype CellIndexType: IndexPathIndexType
+    associatedtype SupplementaryIndexType: IndexPathIndexType
 
     /// Cell configuration closure typealias.
-    typealias CellConfiguration = (cell: CellType, item: ItemType, index: CellIndexType) -> Void
+    associatedtype CellConfiguration = (cell: CellType, item: ItemType, index: CellIndexType) -> Void
 
     /// Supplmentary view configuration closure typealias.
-    typealias SupplementaryViewConfiguration = (supplementaryView: SupplementaryViewType, index: SupplementaryIndexType) -> Void
+    associatedtype SupplementaryViewConfiguration = (supplementaryView: SupplementaryViewType, index: SupplementaryIndexType) -> Void
 
     /// Supplmentary text configuration closure typealias.
-    typealias SupplementaryTextConfiguration = (index: SupplementaryIndexType) -> TextType?
+    associatedtype SupplementaryTextConfiguration = (index: SupplementaryIndexType) -> TextType?
 
     /// The type of the text returned, could be a String, or NSAttributedString for instance.
-    typealias TextType
+    associatedtype TextType
 
     // Registration
 

--- a/Sources/Base/Utilities.swift
+++ b/Sources/Base/Utilities.swift
@@ -89,6 +89,10 @@ class NotificationCenterHandler: NSObject {
     let name: String
     let callback: Callback
 
+    class var selector: Selector {
+        return #selector(NotificationCenterHandler.handleNotification(_:))
+    }
+
     init(name n: String, callback c: Callback) {
         name = n
         callback = c
@@ -109,7 +113,7 @@ extension NSNotificationCenter {
         let handler = NotificationCenterHandler(name: name, callback: callback)
         let center = NSNotificationCenter.defaultCenter()
         center.removeObserver(handler, name: name, object: object)
-        center.addObserver(handler, selector: "handleNotification:", name: name, object: object)
+        center.addObserver(handler, selector: NotificationCenterHandler.selector, name: name, object: object)
         return handler
     }
 }
@@ -120,7 +124,7 @@ public class TargetActionHandler: NSObject {
     public typealias Callback = (sender: AnyObject?) -> Void
 
     public class var selector: Selector {
-        return "handleAction:"
+        return #selector(TargetActionHandler.handleAction(_:))
     }
 
     private let callback: Callback

--- a/Sources/YapDatabase/YapDBFactory.swift
+++ b/Sources/YapDatabase/YapDBFactory.swift
@@ -5,7 +5,7 @@
 import YapDatabase
 
 public protocol UpdatableView {
-    typealias ProcessChangesType
+    associatedtype ProcessChangesType
     var processChanges: ProcessChangesType { get }
 }
 

--- a/Tests/DatasourceProviderTests.swift
+++ b/Tests/DatasourceProviderTests.swift
@@ -10,6 +10,19 @@ import UIKit
 import XCTest
 import TaylorSource
 
+// Convenience shorthands for commonly used selectors.
+private extension Selector {
+
+    // UITableViewDataSource methods
+    static let canEditRow = #selector(UITableViewDataSource.tableView(_:canEditRowAtIndexPath:))
+    static let commitEditingStyle = #selector(UITableViewDataSource.tableView(_:commitEditingStyle:forRowAtIndexPath:))
+    static let canMoveRow = #selector(UITableViewDataSource.tableView(_:canMoveRowAtIndexPath:))
+    static let moveRow = #selector(UITableViewDataSource.tableView(_:moveRowAtIndexPath:toIndexPath:))
+    static let numberOfSectionsInTableView = #selector(UITableViewDataSource.numberOfSectionsInTableView(_:))
+    static let numberOfRowsInSection = #selector(UITableViewDataSource.tableView(_:numberOfRowsInSection:))
+    static let cellForRowAtIndexPath = #selector(UITableViewDataSource.tableView(_:cellForRowAtIndexPath:))
+}
+
 class DatasourceProviderTests: XCTestCase {
 
     struct EditableEventDatasourceProvider: DatasourceProviderType {
@@ -49,11 +62,10 @@ class DatasourceProviderTests: XCTestCase {
         wrapper = TableViewDataSourceProvider(EditableEventDatasourceProvider(data: data))
         let tableViewDataSource = wrapper.tableViewDataSource
         assertTableViewDataSourceImplementsBaseMethods(tableViewDataSource)
-        XCTAssertFalse(tableViewDataSource.respondsToSelector("tableView:canEditRowAtIndexPath:"))
-        XCTAssertFalse(tableViewDataSource.respondsToSelector("tableView:commitEditingStyle:forRowAtIndexPath:"))
-        XCTAssertFalse(tableViewDataSource.respondsToSelector("tableView:canMoveRowAtIndexPath:"))
-        XCTAssertFalse(tableViewDataSource.respondsToSelector("tableView:moveRowAtIndexPath:toIndexPath:"))
-
+        XCTAssertFalse(tableViewDataSource.respondsToSelector(.canEditRow))
+        XCTAssertFalse(tableViewDataSource.respondsToSelector(.commitEditingStyle))
+        XCTAssertFalse(tableViewDataSource.respondsToSelector(.canMoveRow))
+        XCTAssertFalse(tableViewDataSource.respondsToSelector(.moveRow))
     }
 
     func test__provider_with_edit_closures__table_view_datasource_is_editable() {
@@ -67,10 +79,10 @@ class DatasourceProviderTests: XCTestCase {
 
         let tableViewDataSource = wrapper.tableViewDataSource
         assertTableViewDataSourceImplementsBaseMethods(tableViewDataSource)
-        XCTAssertTrue(tableViewDataSource.respondsToSelector("tableView:canEditRowAtIndexPath:"))
-        XCTAssertTrue(tableViewDataSource.respondsToSelector("tableView:commitEditingStyle:forRowAtIndexPath:"))
-        XCTAssertTrue(tableViewDataSource.respondsToSelector("tableView:canMoveRowAtIndexPath:"))
-        XCTAssertTrue(tableViewDataSource.respondsToSelector("tableView:moveRowAtIndexPath:toIndexPath:"))
+        XCTAssertTrue(tableViewDataSource.respondsToSelector(.canEditRow))
+        XCTAssertTrue(tableViewDataSource.respondsToSelector(.commitEditingStyle))
+        XCTAssertTrue(tableViewDataSource.respondsToSelector(.canMoveRow))
+        XCTAssertTrue(tableViewDataSource.respondsToSelector(.moveRow))
     }
 
     func test__editable_provider__receives_calls_for__can_edit() {
@@ -180,8 +192,8 @@ class DatasourceProviderTests: XCTestCase {
     // MARK: - Helpers
 
     func assertTableViewDataSourceImplementsBaseMethods(tableViewDataSource: UITableViewDataSource) {
-        XCTAssertTrue(tableViewDataSource.respondsToSelector("tableView:numberOfRowsInSection:"))
-        XCTAssertTrue(tableViewDataSource.respondsToSelector("tableView:cellForRowAtIndexPath:"))
-        XCTAssertTrue(tableViewDataSource.respondsToSelector("numberOfSectionsInTableView:"))
+        XCTAssertTrue(tableViewDataSource.respondsToSelector(.numberOfRowsInSection))
+        XCTAssertTrue(tableViewDataSource.respondsToSelector(.cellForRowAtIndexPath))
+        XCTAssertTrue(tableViewDataSource.respondsToSelector(.numberOfSectionsInTableView))
     }
 }

--- a/Tests/YapDBObserverTests.swift
+++ b/Tests/YapDBObserverTests.swift
@@ -24,9 +24,8 @@ func numberOfItemChangesOfType(type: YapDatabaseViewChangeType, inChangeset chan
 
 func validateChangeset(expectation: XCTestExpectation, validations: [YapDatabaseViewMappings.Changes]) -> YapDatabaseViewMappings.Changes {
     return { changeset in
-
         for validation in validations {
-            validation(changeset)
+            validation((sections: changeset.sections, items: changeset.items))
         }
         expectation.fulfill()
     }


### PR DESCRIPTION
This PR resolves compilation warnings in both the main project and unit tests.
- Eliminates use of deprecated `++` operator.
- String-based selectors changed to `#selector` syntax.
- `var` parameters redeclared as mutable in closure bodies.
- `typealias` changed to `associatedtype` in protocols.
- Warning about passing tuples fixed.
