### PR TITLE
Changes to NSFRC view update handling

### DIFF
--- a/Sources/CoreData/NSFRCDatasource.swift
+++ b/Sources/CoreData/NSFRCDatasource.swift
@@ -13,45 +13,46 @@ public struct NSFRCDatasource<
     Factory
     where
     Factory: _FactoryType,
-    Factory.ViewType: NSFRCIndexedUpdateConsumer,
+    Factory.ViewType: IndexedUpdateProcessing,
     Factory.CellIndexType == NSFRCCellIndex,
 Factory.SupplementaryIndexType == NSFRCSupplementaryIndex>: DatasourceType {
-    
+
     public typealias FactoryType = Factory
-    
+
     public let identifier: String
     public let factory: Factory
     public var title: String? = .None
     public let updateHandler = NSFRCUpdateHandler()
     public var selectionManager = IndexPathSelectionManager()
-    
+
     private let fetchedResultsController: FetchedResultsControllerType
-    
-    public init(id: String, fetchedResultsController: FetchedResultsControllerType, factory f: Factory) {
+
+    public init(id: String, fetchedResultsController: FetchedResultsControllerType, factory f: Factory, processChanges changes: IndexedUpdateProcessor) {
         self.fetchedResultsController = fetchedResultsController
         self.fetchedResultsController.delegate = updateHandler
+        updateHandler.addUpdateObserver(changes)
         identifier = id
         factory = f
     }
-    
+
     public var numberOfSections: Int {
         return fetchedResultsController.sections?.count ?? 0
     }
-    
+
     public func numberOfItemsInSection(sectionIndex: Int) -> Int {
         if let section = fetchedResultsController.sections?[sectionIndex] {
             return section.numberOfObjects
         }
         return 0
     }
-    
+
     public func itemAtIndexPath(indexPath: NSIndexPath) -> Factory.ItemType? {
         if let obj = fetchedResultsController.objectAtIndexPath(indexPath) as? Factory.ItemType {
             return obj
         }
         return nil
     }
-    
+
     public func cellForItemInView(view: Factory.ViewType, atIndexPath indexPath: NSIndexPath) -> Factory.CellType {
         let selected = selectionManager.enabled && selectionManager.contains(indexPath)
         if let item = itemAtIndexPath(indexPath) {
@@ -60,7 +61,7 @@ Factory.SupplementaryIndexType == NSFRCSupplementaryIndex>: DatasourceType {
         }
         fatalError("No item available at index path: \(indexPath)")
     }
-    
+
     public func viewForSupplementaryElementInView(view: Factory.ViewType, kind: SupplementaryElementKind, atIndexPath indexPath: NSIndexPath) -> Factory.SupplementaryViewType? {
         if
             let section = fetchedResultsController.sections?[indexPath.section],
@@ -71,7 +72,7 @@ Factory.SupplementaryIndexType == NSFRCSupplementaryIndex>: DatasourceType {
         }
         return nil
     }
-    
+
     public func textForSupplementaryElementInView(view: FactoryType.ViewType, kind: SupplementaryElementKind, atIndexPath indexPath: NSIndexPath) -> FactoryType.TextType? {
         if
             let section = fetchedResultsController.sections?[indexPath.section],


### PR DESCRIPTION
Restructured handling of view updates from `NSFetchedResultsController` to be more like that of its YapDatabase counterpart.
